### PR TITLE
Allow user to exclude buckets from check extra718

### DIFF
--- a/checks/check_extra718
+++ b/checks/check_extra718
@@ -26,10 +26,14 @@ extra718(){
         textFail "Access Denied Trying to Get Bucket Logging for $bucket"
         continue
       fi
-      if [[ $(echo "$BUCKET_SERVER_LOG_ENABLED" | grep "^None$") ]]; then
-        textFail "Bucket $bucket has server access logging disabled!"
+      if [[ $EXTRA718_EXCLUDED_BUCKETS && $(echo $bucket | grep $EXTRA718_EXCLUDED_BUCKETS) ]]; then
+        textInfo "Bucket $bucket excluded from check"
       else
-        textPass "Bucket $bucket has server access logging enabled"
+        if [[ $(echo "$BUCKET_SERVER_LOG_ENABLED" | grep "^None$") ]]; then
+          textFail "Bucket $bucket has server access logging disabled!"
+        else
+          textPass "Bucket $bucket has server access logging enabled"
+        fi
       fi
     done
   else

--- a/prowler
+++ b/prowler
@@ -83,12 +83,14 @@ USAGE:
                             (i.e.: ProwlerRole)
       -T                  session durantion given to that role credentials in seconds, default 1h (3600) recommended 12h, requires -R and -T
                             (i.e.: 43200) 
+      -B <buckets>        a regex for buckets to exclude from check extra718
+                            (i.e.: '^bucket-name-prefix.*\|other-prefix-for-a-bucket.*$')
       -h                  this help
   "
   exit
 }
 
-while getopts ":hlLkqp:r:c:g:f:m:M:E:enbVsx:A:R:T:" OPTION; do
+while getopts ":hlLkqp:r:c:g:f:m:M:E:enbVsx:A:R:T:B:" OPTION; do
    case $OPTION in
      h )
         usage
@@ -105,7 +107,7 @@ while getopts ":hlLkqp:r:c:g:f:m:M:E:enbVsx:A:R:T:" OPTION; do
         KEEPCREDREPORT=1
         ;;
      p )
-        PROFILE=$OPTARG
+        PROFILE_OPT=$OPTARG
         ;;
      r )
         REGION_OPT=$OPTARG
@@ -159,6 +161,9 @@ while getopts ":hlLkqp:r:c:g:f:m:M:E:enbVsx:A:R:T:" OPTION; do
         ;;
      T )
         SESSION_DURATION_TO_ASSUME=$OPTARG
+        ;;
+     B )
+        EXTRA718_EXCLUDED_BUCKETS=$OPTARG
         ;;
      : )
         echo ""
@@ -267,7 +272,7 @@ execute_check() {
         fi
       fi
 		  show_check_title $1
-		  $1
+      $1
     else
       textFail "ERROR! Use a valid check name (i.e. check41 or extra71)";
       exit $EXITCODE

--- a/prowler
+++ b/prowler
@@ -271,7 +271,7 @@ execute_check() {
           saveReport
         fi
       fi
-		  show_check_title $1
+      show_check_title $1
       $1
     else
       textFail "ERROR! Use a valid check name (i.e. check41 or extra71)";


### PR DESCRIPTION
Check extra718 makes sure that server access logging is activated for all s3 buckets. However, activating server access logging for the buckets which are themselves used to store other buckets' server access logs would lead to ballooning storage requirements, as each log would itself be logged. Therefore, this check will never succeed in a properly configured AWS setup.

Users should be able to exclude buckets from the check.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
