### PR TITLE
Rewrite check119 to be consistent with upstream

### DIFF
--- a/checks/check119
+++ b/checks/check119
@@ -22,20 +22,19 @@ check119(){
     EC2_DATA=$($AWSCLI ec2 describe-instances $PROFILE_OPT --region $regx --query 'Reservations[].Instances[].[InstanceId, IamInstanceProfile.Arn, State.Name]' --output json)
     EC2_DATA=$(echo $EC2_DATA | jq '.[]|{InstanceId: .[0], ProfileArn: .[1], StateName: .[2]}')
     INSTANCE_LIST=$(echo $EC2_DATA | jq -r '.InstanceId')
-    NON_TERMINATED_INSTANCES=0
-    for instance in $INSTANCE_LIST; do
-      STATE_NAME=$(echo $EC2_DATA | jq -r --arg i "$instance" 'select(.InstanceId==$i)|.StateName')
-      if [[ $STATE_NAME != "terminated" ]]; then
-        ((NON_TERMINATED_INSTANCES++))
-        PROFILEARN=$(echo $EC2_DATA | jq -r --arg i "$instance" 'select(.InstanceId==$i)|.ProfileArn')
-        if [[ $PROFILEARN == "null" ]]; then
-          textFail "$regx: Instance $instance not associated with an instance role." $regx
-        else
-          textPass "$regx: Instance $instance associated with role ${PROFILEARN##*/}." $regx
+    if [[ $INSTANCE_LIST ]]; then
+      for instance in $INSTANCE_LIST; do
+        STATE_NAME=$(echo $EC2_DATA | jq -r --arg i "$instance" 'select(.InstanceId==$i)|.StateName')
+        if [[ $STATE_NAME != "terminated" ]]; then
+          PROFILEARN=$(echo $EC2_DATA | jq -r --arg i "$instance" 'select(.InstanceId==$i)|.ProfileArn')
+          if [[ $PROFILEARN == "null" ]]; then
+            textFail "$regx: Instance $instance not associated with an instance role" $regx
+          else
+            textPass "$regx: Instance $instance associated with role ${PROFILEARN##*/}" $regx
+          fi
         fi
-      fi
-    done
-    if [[ $NON_TERMINATED_INSTANCES -gt 0 ]]; then
+      done
+    else
       textInfo "$regx: No EC2 instances found" $regx
     fi
   done


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Both our fork and the upstream fixed this problem in different ways. This switches our fork to use the upstream's method so it'll be easier to switch back to using theirs.