### PR TITLE
Fix profile opt

### DIFF
--- a/prowler
+++ b/prowler
@@ -113,7 +113,7 @@ while getopts ":hlLkqp:r:c:g:f:m:M:E:x:enbVsSI:A:R:T:w:" OPTION; do
         KEEPCREDREPORT=1
         ;;
      p )
-        PROFILE_OPT=$OPTARG
+        PROFILE=$OPTARG
         ;;
      r )
         REGION_OPT=$OPTARG


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

It turns out that the PROFILE argument is used by `include/aws_profile_loader`, and should indeed be set to PROFILE instead of PROFILE_OPT.

This hasn't broken anything in our fork as we don't make use of this flag, but it should still be fixed.